### PR TITLE
fix: update tag name for event sessions in API router

### DIFF
--- a/src/api/routes/event_sessions.py
+++ b/src/api/routes/event_sessions.py
@@ -32,7 +32,7 @@ from src.crud.event_session import (
 )
 from src.schemas import EventSessionCreate, EventSessionPublic, EventSessionUpdate
 
-router = APIRouter(prefix="/event-sessions", tags=["event_sessions"])
+router = APIRouter(prefix="/event-sessions", tags=["Event Sessions"])
 
 
 @router.get("/", response_model=list[EventSessionPublic])


### PR DESCRIPTION
fix: update tag name for event sessions in API router